### PR TITLE
device-xiaomi-alioth: fix APKBUILD install script

### DIFF
--- a/device/testing/device-xiaomi-alioth/APKBUILD
+++ b/device/testing/device-xiaomi-alioth/APKBUILD
@@ -65,7 +65,7 @@ nonfree_firmware() {
 	"
 	mkdir "$subpkgdir"
 
-	install -Dm644 81-libssc-xiaomi-alioth.rules \
+	install -Dm644 "$srcdir"/81-libssc-xiaomi-alioth.rules \
 		"$subpkgdir"/etc/udev/rules.d/81-libssc-xiaomi-alioth.rules
 
 	install -Dm644 "$srcdir"/hexagonrpcd.confd \


### PR DESCRIPTION
ensure we look in the correct directory for the `81-libssc-xiaomi-alioth.rules` file.

i also wasn't able to get pmbootstrap to build anything until i also rebased/merged upstream pmaports main, but that is left as an exercise to the reader 